### PR TITLE
Feature specimencheckdigit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,16 +6,16 @@ cache: pip
 script: nosetests
 before_deploy: 
 - "python setup.py sdist"
-- "cd dist; md5sum databrowse-0.7.5.tar.gz > databrowse-0.7.5.tar.gz.md5; cd .."
-- "cd dist; sha512sum databrowse-0.7.5.tar.gz > databrowse-0.7.5.tar.gz.sha; cd .."
+- "cd dist; md5sum databrowse-0.7.6.tar.gz > databrowse-0.7.6.tar.gz.md5; cd .."
+- "cd dist; sha512sum databrowse-0.7.6.tar.gz > databrowse-0.7.6.tar.gz.sha; cd .."
 deploy:
   provider: releases
   api_key:
     secure: NvZ/2snnFOsc0l7PDfAj+DWYncUoAhcAK2p5hkDK4Vj4QPDAfMF3vnfQ59tEbxzgFeunPnY35Fr9HX+L8hHCxRlOAN9iRvstZYLBHbUxYi56UxLDeQn+OTED/lo+VOcv+ztludfrRuqOPWLzb9x/BoT4b/ygjNjgBzIKhLd+60O0X9a9dLUoTpyBZlKcbwwxGlAO2kc1g4AzrwQzzgV2lOjLX5KKkzYNt3RVU71tC63b9H5xhQgIRarpVfKFbkbAiE/z0jiba2cWY44t9Vb3Q0W/v2eIKPkHiuBEC4jPz71z74+LdbXoLPcr/h05HpyLp9gCqnfkmBYVlSE4+r8e4dXxuS/mc9jXnvIDmXNgy+O6FMFnjMBLf3sEYliBdcVQfOiEFsICUT6C+B4p0L6EiE0E30tP5b5+75RZhTQab4aj9fHw+/fjM7nWjRBwzBum1pO9CnZR8Ykbb0yJV7q9wufouIfqt07FfmMYe0rvLimwm5Arle8tyifQi0IHl5fRiL1HV3WFD51DqNp7VOm0M4kEpbnVtXNpoEoUcPypw96auPJe8Ql2tUHJdFYt7/UPRolDMVGLt53c/k22As2aeEn0IhO/4JM14hr+NWmoPf32/fN/g56mcMG9W/jufagt4pFGiwiqEIXZkhmy5tTnHGpANraMtArl21PJ7E08h0g=
   file: 
-    - dist/databrowse-0.7.5.tar.gz
-    - dist/databrowse-0.7.5.tar.gz.md5
-    - dist/databrowse-0.7.5.tar.gz.sha
+    - dist/databrowse-0.7.6.tar.gz
+    - dist/databrowse-0.7.6.tar.gz.md5
+    - dist/databrowse-0.7.6.tar.gz.sha
   skip_cleanup: true
   on:
     repo: limatix/databrowse

--- a/databrowse/plugins/db_specimen/db_specimen.py
+++ b/databrowse/plugins/db_specimen/db_specimen.py
@@ -23,7 +23,7 @@
 ## EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,       ##
 ## PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR        ##
 ## PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF    ##
-## LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING      ## 
+## LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING      ##
 ## NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS        ##
 ## SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.              ##
 ##                                                                           ##
@@ -133,6 +133,15 @@ class db_specimen(renderer_class):
                 self._web_support.req.output = "Error Saving File: Incomplete Request"
                 self._web_support.req.response_headers['Content-Type'] = 'text/plain'
                 return [self._web_support.req.return_page()]
+        elif self._content_mode != "raw" and "ajax" in self._web_support.req.form and "checkdigit" in self._web_support.req.form:
+            if "specimen" in self._web_support.req.form:
+                spcstr = self._web_support.req.form['specimen'].value
+                chkdgt = ss.GenerateCheckdigit(spcstr)
+                self._web_support.req.output = spcstr+chkdgt
+                self._web_support.req.response_headers['Content-Type'] = 'text/plain'
+                return [self._web_support.req.return_page()]
+            else:
+                raise self.RendererException('Incomplete Request')
         elif self._content_mode != "raw" and "ajax" in self._web_support.req.form and "addactionitem" in self._web_support.req.form:
             if not "date" in self._web_support.req.form or self._web_support.req.form['date'].value == "":
                 self._web_support.req.output = "Date is a Required Field"

--- a/databrowse/plugins/db_specimen/dbs_edit_specimen_data.xml
+++ b/databrowse/plugins/db_specimen/dbs_edit_specimen_data.xml
@@ -26,7 +26,8 @@
 	<script type="text/javascript"><xsl:attribute name="src"><xsl:value-of select="$resdir"/>/Axel/src/plugins/link.js</xsl:attribute></script>
 	<script type="text/javascript"><xsl:attribute name="src"><xsl:value-of select="$resdir"/>/Axel/src/plugins/richtext.js</xsl:attribute></script>
 	<script type="text/javascript"><xsl:attribute name="src"><xsl:value-of select="$resdir"/>/Axel/src/plugins/video.js</xsl:attribute></script>
-	<script type="text/javascript"><xsl:attribute name="src"><xsl:value-of select="$resdir"/>/Axel/src/plugins/photo.js</xsl:attribute></script>
+  <script type="text/javascript"><xsl:attribute name="src"><xsl:value-of select="$resdir"/>/Axel/src/plugins/photo.js</xsl:attribute></script>
+  <script type="text/javascript"><xsl:attribute name="src"><xsl:value-of select="$resdir"/>/Axel/src/plugins/checkdigit.js</xsl:attribute></script>
 	<script type="text/javascript"><xsl:attribute name="src"><xsl:value-of select="$resdir"/>/Axel/src/filters/common.js</xsl:attribute></script>
 	<script type="text/javascript"><xsl:attribute name="src"><xsl:value-of select="$resdir"/>/Axel/src/filters/documentid.js</xsl:attribute></script>
 	<script type="text/javascript"><xsl:attribute name="src"><xsl:value-of select="$resdir"/>/Axel/src/filters/wiki.js</xsl:attribute></script>

--- a/databrowse/support/crc_algorithms.py
+++ b/databrowse/support/crc_algorithms.py
@@ -1,0 +1,229 @@
+#  pycrc -- parameterisable CRC calculation utility and C source code generator
+#
+#  Copyright (c) 2006-2013  Thomas Pircher  <tehpeh@gmx.net>
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a copy
+#  of this software and associated documentation files (the "Software"), to
+#  deal in the Software without restriction, including without limitation the
+#  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+#  sell copies of the Software, and to permit persons to whom the Software is
+#  furnished to do so, subject to the following conditions:
+#
+#  The above copyright notice and this permission notice shall be included in
+#  all copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+#  IN THE SOFTWARE.
+
+
+"""
+CRC algorithms implemented in Python.
+If you want to study the Python implementation of the CRC routines, then this
+is a good place to start from.
+
+The algorithms Bit by Bit, Bit by Bit Fast and Table-Driven are implemented.
+
+This module can also be used as a library from within Python.
+
+Examples
+========
+
+This is an example use of the different algorithms:
+
+>>> from crc_algorithms import Crc
+>>>
+>>> crc = Crc(width = 16, poly = 0x8005,
+...           reflect_in = True, xor_in = 0x0000,
+...           reflect_out = True, xor_out = 0x0000)
+>>> print("0x%x" % crc.bit_by_bit("123456789"))
+>>> print("0x%x" % crc.bit_by_bit_fast("123456789"))
+>>> print("0x%x" % crc.table_driven("123456789"))
+"""
+
+# Class Crc
+###############################################################################
+class Crc(object):
+    """
+    A base class for CRC routines.
+    """
+
+    # Class constructor
+    ###############################################################################
+    def __init__(self, width, poly, reflect_in, xor_in, reflect_out, xor_out, table_idx_width = None):
+        """The Crc constructor.
+
+        The parameters are as follows:
+            width
+            poly
+            reflect_in
+            xor_in
+            reflect_out
+            xor_out
+        """
+        self.Width          = width
+        self.Poly           = poly
+        self.ReflectIn      = reflect_in
+        self.XorIn          = xor_in
+        self.ReflectOut     = reflect_out
+        self.XorOut         = xor_out
+        self.TableIdxWidth  = table_idx_width
+
+        self.MSB_Mask = 0x1 << (self.Width - 1)
+        self.Mask = ((self.MSB_Mask - 1) << 1) | 1
+        if self.TableIdxWidth != None:
+            self.TableWidth = 1 << self.TableIdxWidth
+        else:
+            self.TableIdxWidth = 8
+            self.TableWidth = 1 << self.TableIdxWidth
+
+        self.DirectInit = self.XorIn
+        self.NonDirectInit = self.__get_nondirect_init(self.XorIn)
+        if self.Width < 8:
+            self.CrcShift = 8 - self.Width
+        else:
+            self.CrcShift = 0
+
+
+    # function __get_nondirect_init
+    ###############################################################################
+    def __get_nondirect_init(self, init):
+        """
+        return the non-direct init if the direct algorithm has been selected.
+        """
+        crc = init
+        for i in range(self.Width):
+            bit = crc & 0x01
+            if bit:
+                crc^= self.Poly
+            crc >>= 1
+            if bit:
+                crc |= self.MSB_Mask
+        return crc & self.Mask
+
+
+    # function reflect
+    ###############################################################################
+    def reflect(self, data, width):
+        """
+        reflect a data word, i.e. reverts the bit order.
+        """
+        x = data & 0x01
+        for i in range(width - 1):
+            data >>= 1
+            x = (x << 1) | (data & 0x01)
+        return x
+
+
+    # function bit_by_bit
+    ###############################################################################
+    def bit_by_bit(self, in_str):
+        """
+        Classic simple and slow CRC implementation.  This function iterates bit
+        by bit over the augmented input message and returns the calculated CRC
+        value at the end.
+        """
+        register = self.NonDirectInit
+        for c in in_str:
+            octet = ord(c)
+            if self.ReflectIn:
+                octet = self.reflect(octet, 8)
+            for i in range(8):
+                topbit = register & self.MSB_Mask
+                register = ((register << 1) & self.Mask) | ((octet >> (7 - i)) & 0x01)
+                if topbit:
+                    register ^= self.Poly
+
+        for i in range(self.Width):
+            topbit = register & self.MSB_Mask
+            register = ((register << 1) & self.Mask)
+            if topbit:
+                register ^= self.Poly
+
+        if self.ReflectOut:
+            register = self.reflect(register, self.Width)
+        return register ^ self.XorOut
+
+
+    # function bit_by_bit_fast
+    ###############################################################################
+    def bit_by_bit_fast(self, in_str):
+        """
+        This is a slightly modified version of the bit-by-bit algorithm: it
+        does not need to loop over the augmented bits, i.e. the Width 0-bits
+        wich are appended to the input message in the bit-by-bit algorithm.
+        """
+        register = self.DirectInit
+        for c in in_str:
+            octet = ord(c)
+            if self.ReflectIn:
+                octet = self.reflect(octet, 8)
+            for i in range(8):
+                topbit = register & self.MSB_Mask
+                if octet & (0x80 >> i):
+                    topbit ^= self.MSB_Mask
+                register <<= 1
+                if topbit:
+                    register ^= self.Poly
+            register &= self.Mask
+        if self.ReflectOut:
+            register = self.reflect(register, self.Width)
+        return register ^ self.XorOut
+
+
+    # function gen_table
+    ###############################################################################
+    def gen_table(self):
+        """
+        This function generates the CRC table used for the table_driven CRC
+        algorithm.  The Python version cannot handle tables of an index width
+        other than 8.  See the generated C code for tables with different sizes
+        instead.
+        """
+        table_length = 1 << self.TableIdxWidth
+        tbl = [0] * table_length
+        for i in range(table_length):
+            register = i
+            if self.ReflectIn:
+                register = self.reflect(register, self.TableIdxWidth)
+            register = register << (self.Width - self.TableIdxWidth + self.CrcShift)
+            for j in range(self.TableIdxWidth):
+                if register & (self.MSB_Mask << self.CrcShift) != 0:
+                    register = (register << 1) ^ (self.Poly << self.CrcShift)
+                else:
+                    register = (register << 1)
+            if self.ReflectIn:
+                register = self.reflect(register >> self.CrcShift, self.Width) << self.CrcShift
+            tbl[i] = register & (self.Mask << self.CrcShift)
+        return tbl
+
+
+    # function table_driven
+    ###############################################################################
+    def table_driven(self, in_str):
+        """
+        The Standard table_driven CRC algorithm.
+        """
+        tbl = self.gen_table()
+
+        register = self.DirectInit << self.CrcShift
+        if not self.ReflectIn:
+            for c in in_str:
+                tblidx = ((register >> (self.Width - self.TableIdxWidth + self.CrcShift)) ^ ord(c)) & 0xff
+                register = ((register << (self.TableIdxWidth - self.CrcShift)) ^ tbl[tblidx]) & (self.Mask << self.CrcShift)
+            register = register >> self.CrcShift
+        else:
+            register = self.reflect(register, self.Width + self.CrcShift) << self.CrcShift
+            for c in in_str:
+                tblidx = ((register >> self.CrcShift) ^ ord(c)) & 0xff
+                register = ((register >> self.TableIdxWidth) ^ tbl[tblidx]) & (self.Mask << self.CrcShift)
+            register = self.reflect(register, self.Width + self.CrcShift) & self.Mask
+
+        if self.ReflectOut:
+            register = self.reflect(register, self.Width)
+        return register ^ self.XorOut
+

--- a/databrowse/support/specimen_support.py
+++ b/databrowse/support/specimen_support.py
@@ -23,7 +23,7 @@
 ## EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,       ##
 ## PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR        ##
 ## PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF    ##
-## LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING      ## 
+## LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING      ##
 ## NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS        ##
 ## SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.              ##
 ##                                                                           ##
@@ -38,6 +38,7 @@
 
 import os
 from lxml import etree
+import crc_algorithms
 
 _specimendb = '/databrowse/specimens'
 NS = {"specimen": "http://thermal.cnde.iastate.edu/specimen"}
@@ -46,7 +47,7 @@ OUTPUT_STRING = 0
 OUTPUT_ELEMENT = 1
 OUTPUT_ETREE = 2
 norecursion = []
-attributekeys = { 
+attributekeys = {
                   NSSTR + 'dimension': 'direction',
                   NSSTR + 'direction': 'name',
                   NSSTR + 'reference': 'face',
@@ -124,7 +125,7 @@ def GetSpecimen(specimen, output=OUTPUT_STRING, specimendb=_specimendb):
         else:
             raise SpecimenException('Invalid Return Type')
         pass
-        
+
     elif len(groupidelem) == 1:
         groupid = groupidelem[0].text
 
@@ -228,7 +229,7 @@ def _combine_element(one, other, group):
                         if not el.get('fromgroup'):
                             child.set('fromgroup', group)
                         mapping[tagname(el)].append(child)
-            else:   
+            else:
                 try:
                     # Recursively process the element, and update it in the same way
                     _combine_element(mapping[tagname(el)], el, group)
@@ -240,3 +241,13 @@ def _combine_element(one, other, group):
                     # Just add it
                     one.append(el)
     pass
+
+def GenerateCheckdigit(basename):
+   alg = crc_algorithms.Crc(width = 4, poly = 64+2+1, reflect_in=False,
+                            xor_in=0, reflect_out=False, xor_out=0)
+   crc = alg.bit_by_bit(basename) & ((1<<4)-1) # Calc CRC and limit to 15
+   letters="ACEFGHJKLMPRTWXN"
+   crcletter=letters[crc]
+   return crcletter
+
+

--- a/databrowse_wsgi/resources/Axel/src/plugins/checkdigit.js
+++ b/databrowse_wsgi/resources/Axel/src/plugins/checkdigit.js
@@ -1,0 +1,760 @@
+/* ***** BEGIN LICENSE BLOCK *****
+ *
+ * Copyright (C) 2009, 2010, 2011  Stéphane Sire
+ *
+ * This file is part of the Adaptable XML Editing Library (AXEL), version 1.1.2-beta 
+ *
+ * Adaptable XML Editing Library (AXEL) is free software ; you can redistribute it 
+ * and/or modify it under the terms of the GNU Lesser General Public License (the "LGPL")
+ * as published by the Free Software Foundation ; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * The library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY ; 
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
+ * PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this library ; 
+ * if not, write to the Free Software Foundation, Inc., 59 Temple Place, Suite 330, 
+ * Boston, MA 02111-1307 USA.
+ *
+ * Web site : http://media.epfl.ch/Templates/
+ * 
+ * Author(s) : Stéphane Sire, Antoine Yersin
+ * 
+ * ***** END LICENSE BLOCK ***** */
+
+/**
+ * Class CheckDigitFactory (static)
+ * 
+ * @class CheckDigitFactory
+ * @version beta
+ */
+xtiger.editor.CheckDigitFactory = (function CheckDigitFactory() {
+
+	/**
+	 * @name _CheckDigitModel
+	 * @class _CheckDigitModel
+	 */
+	var _CheckDigitModel = function(aHandleNode, aDocument) {
+
+		/*
+		 * Default parameters for the video editor. Parameters meaning and
+		 * possible values are documented below.
+		 */
+		var _DEFAULT_PARAMS = {
+			device : 'text-device',
+			type : 'input',
+			layout : 'placed',
+			shape : 'self',
+			expansion : 'grow',
+			clickthrough : 'true', // FIXME: use a real boolean ?
+			enablelinebreak : 'false'
+		};
+
+		/**
+		 * The HTML node used as handle by the editor.
+		 */
+		this._handle = aHandleNode;
+
+		/**
+		 * The data handled by *this* model
+		 */
+		this._data = null;
+
+		/**
+		 * The default data as specified in the xt:use node
+		 */
+		this._defaultData = this._data;
+
+		/**
+		 * HTML element to represents an editor containing no data
+		 */
+		this._noData = this._handle.firstChild;
+
+		/**
+		 * A reference to the DOM document containing the editor
+		 */
+		this._document = aDocument;
+
+		/**
+		 * The actual parameters used by *this* instance
+		 */
+		this._params = _DEFAULT_PARAMS;
+
+		/**
+		 * If true, the editor is optional
+		 */
+		this._isOptional = false;
+
+		/**
+		 * If true, the optional editor is set. Irrelevant if not optional
+		 */
+		this._isOptionSet = false;
+
+		/**
+		 * The HTML checkbox for optional editors. Sets in init() method
+		 */
+		this._optCheckBox;
+
+		/**
+		 * The device object used to edit this model. It is sets in init()
+		 * function
+		 */
+		this._device = null;
+		
+		/**
+		 * A stored seed for this model
+		 */
+		this._seed = null;
+
+		/**
+		 * if true, the model's data was modified and is no longer equals to the
+		 * default data.
+		 */
+		this._isModified = false;
+
+    this._ButtonEl = null;
+
+		/**
+		 * A unique string that identifies *this* instance
+		 */
+		this._uniqueKey;
+
+		/* Call the create method for delegation purposes */
+		this.create();
+
+	};    
+	
+	/** @memberOf _CheckDigitModel */
+	_CheckDigitModel.prototype = {
+
+		/*
+		 * Sets *this* instance data. Takes the handle and updates its DOM content.
+		 */
+		_setData : function (aData) {
+			if (this._handle.firstChild)
+				this._handle.firstChild.data = aData;
+			this._data = aData;
+		},
+
+		/**
+		 * This method is called at the instance's creation time. It may serves
+		 * as a "hook" to add a custom behavior by the means of the delegation
+		 * pattern.
+		 */
+		create : function () {
+			// nope
+		},
+
+		/**
+		 * <p>
+		 * Initialization function, called by the model's factory after object's
+		 * instanciation. Cares to sets the default content, to parse and sets
+		 * the various parameters and to call the awake() method.
+		 * </p>
+		 * 
+		 * @param {string}
+		 *            aDefaultData
+		 * @param {string|object}
+		 *            aParams Either the parameter string from the <xt:use> node
+		 *            or the parsed parameters object from the seed
+		 * @param {string}
+		 *            aOption If the parameter is not null, the editor is
+		 *            optional. If its value equals "set", the editor is set by
+		 *            default
+		 * @param {string}
+		 *            aUniqueKey A unique string (no two editor have the same)
+		 *            to provide an unambiguous identifier even among repeated
+		 *            editor
+		 */
+		init : function (aDefaultData, aParams, aOption, aUniqueKey, aRepeater) {
+			if (aParams) { /* parse parameters */
+				if (typeof (aParams) == 'string')
+					xtiger.util.decodeParameters(aParams, this._params);
+				else if (typeof (aParams) == 'object')
+					this._params = aParams;
+			}
+			/* sets up initial content */
+			if (aDefaultData && typeof aDefaultData == 'string') { 
+				this._defaultData = aDefaultData;
+			} else {
+				this._defaultData = 'click to edit';
+			}                              
+			this._data = this._defaultData; // Quirck in case _setData is overloaded and checks getDefaultData()
+			this._setData(this._defaultData);
+			this._isOptional = aOption ? true : false;
+			if (aOption) { /* the editor is optional */
+				this._optCheckBox = this._handle.previousSibling;
+				if (aOption == 'unset')
+					this._isOptionSet = true; // Quirk to prevent unset to return immediately
+				(aOption == 'set') ? this.set(false) : this.unset(false);
+			}
+      this._buttonEl = this._handle.nextSibling.firstChild;
+			this._uniqueKey = aUniqueKey;
+			if (this.getParam('hasClass')) {
+				xtdom.addClassName(this._handle, this.getParam('hasClass'));
+			}
+			var _deviceFactory = this._params['device'] ? 
+					xtiger.factory(this._params['device']) : 
+					xtiger.factory(this._params['defaultDevice']);
+			this._device = _deviceFactory.getInstance(this._document,
+					this._params['type'], this._params['layout']);
+			this.awake();
+		},
+
+		/**
+		 * Creates (lazy creation) an array to "seed" *this* model. Seeding
+		 * occurs in a repeat context. 
+		 * 
+		 * @return
+		 */
+		makeSeed : function () {
+			if (!this._seed)
+				this._seed = [ xtiger.editor.TextFactory, this._defaultData,
+					this._params, this._isOptional ];
+			return this._seed;
+		},
+		
+		/**
+		 * Called when the editor is removed by a repeater. Does nothing by default,
+		 * it is declared so that it can be filtered.
+		 * 
+		 * @return
+		 */
+		remove : function () {
+		},
+
+		/**
+		 * <p>
+		 * Returns true if *this* object is able to perform the function whose
+		 * name is given as parameter.
+		 * </p>
+		 * 
+		 * <p>
+		 * This function implements the can/execute delegation pattern, this
+		 * pattern allows a filter to easily extend the instance API with
+		 * specific methods. Those methods are called from various devices such
+		 * as the text device.
+		 * </p>
+		 * 
+		 * @param {string}
+		 *            aFunction The name of the function
+		 * @return {boolean} True if *this* object as a function property with
+		 *         the given name, false otherwise.
+		 */
+		can : function (aFunction) {
+			return typeof this[aFunction] == 'function';
+		},
+
+		/**
+		 * <p>
+		 * Calls on *this* instance the function whose name is given as
+		 * paramter, giving it the provided parameter (may be null). Returns the
+		 * result.
+		 * </p>
+		 * 
+		 * <p>
+		 * This function implements the can/execute delegation pattern, this
+		 * pattern allows a filter to easily extend the instance API with
+		 * specific methods. Those methods are called from various devices such
+		 * as the text device.
+		 * </p>
+		 * 
+		 * @param {string}
+		 *            aFunction The name of the function
+		 * @param {any}
+		 *            aParam A parameter whose type is not constrained
+		 * @return {any} The return value of the called function.
+		 */
+		execute : function (aFunction, aParam) {
+			return this[aFunction](aParam);
+		},
+
+		/**              
+		 * <p>Loads the editor with data in the point in the data source passed as parameters.
+		 * Unsets the editor and shows the default content if the point is -1 
+		 * (i.e. it doesn't exists in the source tree). Shows the default content and considers
+		 * the editor as set if the point is not -1 but is empty. This can happen for instance 
+		 * with empty tags in the source tree (e.g. <data/>).</p>
+		 *
+		 *<p>Initializes the option status of the editor (set or unset),
+		 * and the modification status (setModified)</p>
+		 * 
+		 * @param {Array}
+		 *            aPoint
+		 * @param aDataSrc
+		 */
+		load : function (aPoint, aDataSrc) {
+			var _value;
+			if (aPoint !== -1) { 
+				_value = aDataSrc.getDataFor(aPoint);
+			  this._setData(_value || this._defaultData);
+			  this._isModified = (_value !=  this._defaultData);
+			  this.set(false);
+			} else {
+		      this.clear(false);
+  			}
+		},    
+
+		/**
+		 * Writes the editor's current data into the given logger.
+		 * 
+		 * @param aLogger
+		 */
+		save : function (aLogger) {
+			if (this.isOptional() && !this._isOptionSet) {
+				aLogger.discardNodeIfEmpty();
+				return;
+			}
+			if (!this._data)
+				return;
+			aLogger.write(this._data);
+		},
+
+		/**
+		 * <p>
+		 * Updates this model with the given data.
+		 * </p>
+		 * 
+		 * <p>
+		 * If *this* instance is optional and "unset", autocheck it.
+		 * </p>
+		 * 
+		 * @param {string}
+		 *            aData The new value to be stored by *this* model's
+		 *            instance
+		 */
+		update : function (aData) {                             
+			if (aData == this._data) { // no change
+			  return; 
+			}
+			// normalizes text (empty text is set to _defaultData)
+			if (aData.search(/\S/) == -1 || (aData == this._defaultData)) {
+				this.clear(true);
+				return;
+			}
+			this._setData(aData);
+			this._isModified = true;
+			this.set(true);
+		},
+
+		/**
+		 * Clears the model and sets its data to the default data.
+		 * Unsets it if it is optional and propagates the new state if asked to.     
+		 *
+		 * @param {doPropagate}
+		 *            a boolean indicating wether to propagate state change
+		 *            in the repeater chain, UNSUPPORTED at that time		 
+		 */
+		clear : function (doPropagate) {
+			this._setData(this._defaultData);
+			this._isModified = false;
+			if (this.isOptional() && this.isSet())
+				this.unset(doPropagate);
+		},
+		
+		/* aliases the clear method */
+		setDefaultData: this.clear,
+
+		/**
+		 * Returns the editor's current data
+		 * 
+		 * @return {String} The editor's current data
+		 */
+		getData : function () {
+			return this._data;
+		},
+		
+		/**
+		 * Returns the default data for *this* model.
+		 * 
+		 * @return {String} The default data
+		 */
+		getDefaultData: function () {
+			return this._defaultData;
+		},
+
+		/**
+		 * Returns the editor's current handle, that is, the HTML element where
+		 * the editor is "planted".
+		 * 
+		 * @return {HTMLElement} The editor's handle
+		 */
+		getHandle : function (inDOMOnly) {
+			if(inDOMOnly) {
+				// test if *this* instance is being edited and has a "placed" layout
+				if (this._params['layout'] == 'placed' && this._device && this._device.getCurrentModel() == this)
+					return this._device.getHandle();
+			}
+			return this._handle;
+		},
+		
+		/**
+		 * Getter for *this* instance owner document.
+		 * 
+		 * @return {DOMDocument} The DOM document holding *this* model
+		 */
+		getDocument : function () {
+			return this._document;
+		},
+
+		/**
+		 * Returns a DOM node used to set the device's handle size.
+		 */
+		getGhost : function () {
+			var _s = this._params['shape']; // we only check first char is p
+											// like 'parent'
+			return (_s && _s.charAt(0) == 'p') ? this._handle.parentNode
+					: this._handle;
+		},
+
+		/**
+		 * Gets *this* instance's parameter whose name is given in arg
+		 * 
+		 * @return {any} The parameter stored under the given key
+		 */
+		getParam : function (aKey) {
+			return this._params[aKey];
+		},
+
+		/**
+		 * Returns the unique key associated with *this* instance. The returned
+		 * key is unique within the whole document.
+		 * 
+		 * @return {string} The unique key
+		 */
+		getUniqueKey : function () {
+			return this._uniqueKey;
+		},
+
+		/**
+		 * Returns true if the model contains data which is no longer the defaut
+		 * data, either because a load() call modified it or because an user's
+		 * interaction has occured.
+		 * 
+		 * @return {boolean} True if the data was changed, false otherwise.
+		 */
+		isModified : function () {
+			return this._isModified;
+		},
+		
+		/**
+		 * Sets the isModified flag. Useless unless the update or load methods
+		 * are filtered by a filter which need to control the isModified
+		 * behavior.
+		 * 
+		 * @param {boolean}
+		 *            isModified The new value for the isModified flag
+		 */
+		setModified : function (isModified) {
+			this._isModified = isModified;
+		},
+
+		/**
+		 * Returns true if the model's editor is able to be put into a chain of
+		 * focus. Chains of focus are a list of editor that can be accessed by
+		 * iterating with the "tab" key (this feature is better known as the
+		 * "tab-navigation" feature).
+		 * 
+		 * @return {boolean} True if the model should be put into a chain of
+		 *         focus, false otherwise.
+		 */
+		isFocusable : function () {
+			return !this._params['noedit'];
+		},
+
+		/**
+		 * Gives the focus to *this* instance. Called by the tab navigation
+		 * manager.
+		 */
+		focus : function () {
+			this.startEditing({shiftKey: true}); // Hack to autoselect content
+		},
+
+		/**
+		 * Takes the focus away from *this* instance. Called by the tab
+		 * navigation manager.
+		 */
+		unfocus : function () {
+			this.stopEditing();
+		},
+
+		/**
+		 * Returns the optionality status of *this* instance. True if the model
+		 * is optional, false otherwise.
+		 */
+		isOptional : function () {
+			return this._isOptional;
+		},
+
+		/**
+		 * Returns the optionality status of *this* model, that is, if it
+		 * is set or unset. Only relevant if the model IS optional
+		 * 
+		 * @return {boolean} True if the model is optional and set, false
+		 *         otherwise
+		 *   
+		 * @see #isOptional()
+		 */
+		isSet : function () {
+			return this._isOptional && (this._isOptionSet ? true : false);
+		},
+
+		/**
+		 * Sets the editor option status to "set" (i.e. true) if it is optional.
+		 * Also propagates the change to the repeater chain if asked too and
+		 * this either it is optional or not.
+		 * 
+		 * @param {doPropagate}
+		 *            a boolean indicating wether to propagate state change in
+		 *            the repeater chain
+		 */
+		set : function(doPropagate) {
+			// propagates state change in case some repeat ancestors are unset
+			// at that moment
+			if (doPropagate) {
+				if (!this._params['noedit']) {
+					xtiger.editor.Repeat.autoSelectRepeatIter(this.getHandle(true));
+				}
+				xtdom.removeClassName(this._handle, 'axel-repeat-unset'); // fix if *this* model is "placed" and the handle is outside the DOM at the moment
+			}
+			if (this._isOptionSet) // Safety guard (defensive)
+				return;
+			this._isOptionSet = true;
+			if (this._isOptional) {
+				xtdom.removeClassName(this._handle, 'axel-option-unset');
+				xtdom.addClassName(this._handle, 'axel-option-set');
+				this._optCheckBox.checked = true;                          
+			}            
+		},
+	
+		/**
+		 * Sets the editor option status to "unset" (i.e. false) if it is
+		 * optional.
+		 * 
+		 * @param {doPropagate}
+		 *            a boolean indicating wether to propagate state change in
+		 *            the repeater chain, UNSUPPORTED at that time
+		 */
+		unset : function (doPropagate) {
+			if (!this._isOptionSet) // Safety guard (defensive)
+				return;
+			this._isOptionSet = false;
+			if (this._isOptional) {
+				xtdom.removeClassName(this._handle, 'axel-option-set');
+				xtdom.addClassName(this._handle, 'axel-option-unset');
+				this._optCheckBox.checked = false;                    
+			}
+		},
+	
+		/**
+		 * Awakes the editor to DOM's events, registering the callbacks for them.
+		 * 
+		 * TODO stores the callback to be able to remove them at will
+		 */
+		awake : function () {
+			var _this = this;
+			if (!this._params['noedit']) {
+				xtdom.addClassName(this._handle, 'axel-core-editable');
+				xtdom.addEventListener(this._handle, 'click', function(ev) {
+					_this.startEditing(ev);
+				}, true);
+			}	
+			if (this.isOptional()) {
+				xtdom.addEventListener(this._optCheckBox, 'click', function(ev) {
+					_this.onToggleOpt(ev);
+				}, true);
+			}
+      xtdom.addEventListener(this._buttonEl, 'click', function(ev) {
+        _this.onClickCheckdigit(ev);
+        }, true);
+		},
+	
+		/**
+		 * Starts an edition process on *this* instance's device.
+		 * 
+		 * @param {DOMEvent}
+		 *            aEvent The event triggering the start of an edition
+		 *            process
+		 */
+		startEditing : function (aEvent) {
+			var _doSelect = aEvent ? (!this._isModified || aEvent.shiftKey) : false;
+			this._device.startEditing(this, aEvent, _doSelect);
+		},
+
+    onClickCheckdigit : function (aEvent) {
+      this.stopEditing();
+      var curdata = this._data;
+      if (window.location.search != ''){
+        var ajaxurl = window.location.href + "&ajax&checkdigit";
+      }
+      else
+      {
+        var ajaxurl = window.location.href + "?ajax&checkdigit";
+      }
+      fd = new FormData();
+      fd.append('specimen', curdata);
+      $.ajax({
+        async:'false',
+        cache:'false',
+        contentType: false,
+        data: fd,
+        dataType: "text",
+        type: "POST",
+        processData: false,
+        url: ajaxurl,
+        context: this,
+        success: function (data, textStatus, jqXHR){
+            this.stopEditing();
+            this._setData(data);
+          },
+        error: function (jqXHR, textStatus, errorThrown){
+            alert("Error Getting Checkdigit: " + errorThrown);
+          }
+      });
+    },
+
+		/**
+		 * Stops the edition process on the device
+		 */
+		stopEditing : function () {
+			this._device.stopEditing(false, false);
+		},
+
+		/**
+		 * Handler for the option checkbox, toggles the selection state.
+		 */
+		onToggleOpt : function (ev) {
+			this._isOptionSet ? this.unset(true) : this.set(true);
+		}
+	}; /* END of _CheckDigitModel class */
+
+	/* Base string for key */
+	var _BASE_KEY = 'text';
+
+	/* a counter used to generate unique keys */
+	var _keyCounter = 0;
+
+ 	return {
+
+		/**
+		 * <p>
+		 * Creates a DOM model for the text editor. This DOM model represents
+		 * the default content for the text editor. If a default content is
+		 * specified in the template, the content is updated later, in the
+		 * init() function.
+		 * </p>
+		 * 
+		 * @param {HTMLElement}
+		 *            aContainer the HTML node where to implant the editor
+		 * @param {XTNode}
+		 *            aXTUse the XTiger use node that caused this editor to be
+		 *            implanted here
+		 * @param {HTMLDocument}
+		 *            aDocument the current HTML document (in the DOM
+		 *            understanding of a "document") being processed
+		 * @return {HTMLElement} The created HTML element
+		 */
+		createModel : function createModel (aContainer, aXTUse, aDocument) {
+			var _handletag = aXTUse.getAttribute('handle');
+			_handletag = _handletag ? _handletag : 'span';
+			var _handle = xtdom.createElement(aDocument, _handletag);
+			var _content = xtdom.createTextNode(aDocument, '');
+			_handle.appendChild(_content);
+			xtdom.addClassName(_handle, 'axel-core-on');
+			var option = aXTUse.getAttribute('option');
+			if (option) {
+				var check = xtdom.createElement(aDocument, 'input');
+				xtdom.setAttribute(check, 'type', 'checkbox');
+				xtdom.addClassName(check, 'axel-option-checkbox');
+				aContainer.appendChild(check);
+			}
+      var tmpdiv = xtdom.createElement(aDocument, "div");
+      xtdom.addClassName(tmpdiv, "btn-group clearfix");
+      xtdom.setAttribute(tmpdiv, "style", "float:right");
+      var _buttontag = xtdom.createElement(aDocument, "a");
+      xtdom.addClassName(_buttontag, "btn info");
+      xtdom.setAttribute(_buttontag, "style", "cursor:pointer");
+      _buttontag.text = "Add Check Digit";
+      tmpdiv.appendChild(_buttontag);
+			aContainer.appendChild(_handle);
+      aContainer.appendChild(tmpdiv);
+			return _handle;
+		},
+
+		/**
+		 * <p>
+		 * Creates the editor's from an XTiger &lt;xt:use&gt; element. This
+		 * method is responsible to extract the default content as well as the
+		 * optional parameters from the &lt;xt:use&gt; element. See the method
+		 * implementation for the supported default content formats.
+		 * </p>
+		 * 
+		 * @param {HTMLElement}
+		 *            aHandleNode The HTML node used as handle by the created
+		 *            editor
+		 * @param {XMLElement}
+		 *            aXTUse element The &lt;xt:use&gt; element that yields the
+		 *            new editor
+		 * @param {DOM
+		 *            document} aDocument A reference to the containing DOM
+		 *            document
+		 * @return {_TetModel} A new instance of the _CheckDigitModel class
+		 */
+		createEditorFromTree : function createEditorFromTree (aHandleNode, aXTUse, aDocument) {
+			var _data = xtdom.extractDefaultContentXT(aXTUse);
+			if (_data && (_data.search(/\S/) == -1)) { // empty string
+				_data = null;
+			}
+			var _model = new _CheckDigitModel(aHandleNode, aDocument);
+			var _param = {};
+			xtiger.util.decodeParameters(aXTUse.getAttribute('param'), _param);
+			if (_param['filter'])
+				_model = this.applyFilters(_model, _param['filter']);
+			_model.init(_data, aXTUse.getAttribute('param'), 
+			  aXTUse.getAttribute('option'), this.createUniqueKey());
+			return _model;
+		},
+
+		/**
+		 * <p>
+		 * Creates an editor from a seed. The seed must carry the default data
+		 * content as well as the parameters (as a string) information. Those
+		 * infos are used to init the new editor.
+		 * </p>
+		 * 
+		 * @param {Seed}
+		 *            aSeed The seed from which the new editor is built
+		 * @param {HTMLElement}
+		 *            aClone The cloned handle where to implant the editor
+		 * @param {DOM
+		 *            Document} aDocument the document containing the editor
+		 * @return {_CheckDigitModel} The new instance of the _VideoModel class
+		 * 
+		 * @see _CheckDigitModel#makeSeed()
+		 */
+		createEditorFromSeed : function createEditorFromSeed (aSeed, aClone, aDocument, aRepeater) {
+			var _model = new _CheckDigitModel(aClone, aDocument);
+			var _defaultData = aSeed[1];
+			var _params = aSeed[2];
+			var _option = aSeed[3];
+			if (_params['filter'])
+				_model = this.applyFilters(_model, _params['filter']);
+			_model.init(_defaultData, _params, _option, this.createUniqueKey(), aRepeater);
+			return _model;
+		},
+	
+		/**
+		 * Create a unique string. Each call to this method returns a different
+		 * one.
+		 * 
+		 * @return {string} A unique key
+		 */
+		createUniqueKey : function createUniqueKey () {
+			return _BASE_KEY + (_keyCounter++);
+		}
+	}
+})();
+
+xtiger.editor.Plugin.prototype.pluginEditors['checkdigit']
+  = xtiger.util.filterable('checkdigit', xtiger.editor.CheckDigitFactory);

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 lxml>=3.2.0
 file-magic>=0.1
 numpy>=1.8.0
-pillow>=2.3.0
+pillow>=2.3.0,<4
 qrcode>=4.0
 unittest2>=0.5.1

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ setup(
         'lxml>=3.2.0',
         'file-magic>=0.1',
         'numpy>=1.8.0',
-        'pillow>=2.3.0',
+        'pillow>=2.3.0,<4',
         'qrcode>=4.0',
         'unittest2>=0.5.1'
     ],

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     description="An Extensible Data Management Platform",
     keywords="databrowse data management",
     url="http://limatix.org",
-    version='0.7.5',
+    version='0.7.6',
     packages=find_packages(exclude=['databrowse_wsgi', 'tests', 'test_*']),
     package_data = {'':['*.conf', '*.xml']},
     license="BSD-3",


### PR DESCRIPTION
This feature enhancement provides an update to the specimen plugin to provide an Ajax interface for computing the CRC4 checkdigit for a specimen name.  This enhancement also provides a new Axel editor plugin that produces a button to query the check digit for a specimen id and fill it in automatically.  This can be used by modifying the xhtml template for a parameter of interest in a similar fashion:

```
<xt:component name="id">
    <tr><th width="25%">Specimen ID</th><td><xt:use types="checkdigit" option="unset"/></td></tr> 
</xt:component>
```